### PR TITLE
Fix gwasm_dispatcher package name in example

### DIFF
--- a/gwasm-dispatcher/src/lib.rs
+++ b/gwasm-dispatcher/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Examples
 //!
 //! ```edition2018
-//! use gwasm_api::{dispatcher, SplitContext};
+//! use gwasm_dispatcher::{dispatcher, SplitContext};
 //!
 //! fn main() {
 //!     dispatcher::run(


### PR DESCRIPTION
It looks like the package name of gwasm_dispatcher hadn't been updated in the first example.